### PR TITLE
fix url typo

### DIFF
--- a/contents/zh/basics/inspiration.md
+++ b/contents/zh/basics/inspiration.md
@@ -2,6 +2,6 @@
 
 当你有“不知道图表应该设计成什么样”或者“不知道如何使用 ECharts 实现某种效果”的疑问的时候，以下列表可以提供一些思路。
 
-- [ECharts 官方实例](${mainSitePath}/examples)
+- [ECharts 官方实例](${mainSitePath}examples)
 - 本手册的“应用篇 - 常用图表类型”
 - [makeapie.com](https://www.makeapie.com/) 社区用户的作品集


### PR DESCRIPTION
From `https://echarts.apache.org//examples` to `https://echarts.apache.org/examples`, perhaps you should change `mainSitePath`?