### PR TITLE
fix: 切换页面时应回到顶部

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -26,6 +26,12 @@ export default {
               behavior: 'smooth'
             })
         }
+      } else {
+        document.getElementsByClassName('page-main')[0].scrollTo({
+          top: 0,
+          left: 0,
+          behavior: 'smooth'
+        })
       }
     }
   },


### PR DESCRIPTION
fix: 前一个页面滚到最低下，点击左边菜单跳转新页面时，页面在中部，没有回到顶部，需要手动滚动顶部阅读