### PR TITLE
Replace jQuery and xhr example with fetch

### DIFF
--- a/contents/en/concepts/style.md
+++ b/contents/en/concepts/style.md
@@ -26,11 +26,13 @@ Other themes are not included by default, and need to load them ourselves if we 
 If a theme is downloaded as a JSON file, we should register it by ourselves, for example:
 
 ```js
-var xhr = new XMLHttpRequest();
-// Assume the theme name is "vintage".
-$.getJSON('xxx/xxx/vintage.json', function(themeJSON) {
-  echarts.registerTheme('vintage', JSON.parse(themeJSON));
-  var chart = echarts.init(dom, 'vintage');
+fetch('xxx/xxx/vintage.json')
+  .then(r => r.json())
+  .then(theme => {
+    // Assume the theme name is "vintage".
+    echarts.registerTheme('vintage', JSON.parse(theme));
+    var chart = echarts.init(dom, 'vintage');
+  })
 });
 ```
 

--- a/contents/en/concepts/style.md
+++ b/contents/en/concepts/style.md
@@ -26,14 +26,13 @@ Other themes are not included by default, and need to load them ourselves if we 
 If a theme is downloaded as a JSON file, we should register it by ourselves, for example:
 
 ```js
-fetch('xxx/xxx/vintage.json')
+// Assume the theme name is "vintage".
+fetch('theme/vintage.json')
   .then(r => r.json())
   .then(theme => {
-    // Assume the theme name is "vintage".
-    echarts.registerTheme('vintage', JSON.parse(theme));
+    echarts.registerTheme('vintage', theme);
     var chart = echarts.init(dom, 'vintage');
   })
-});
 ```
 
 If a theme is downloaded as a JS file, it will auto register itself:

--- a/contents/zh/concepts/style.md
+++ b/contents/zh/concepts/style.md
@@ -27,10 +27,12 @@ var chart = echarts.init(dom, 'dark');
 
 ```js
 // 假设主题名称是 "vintage"
-$.getJSON('xxx/xxx/vintage.json', function(themeJSON) {
-  echarts.registerTheme('vintage', JSON.parse(themeJSON));
-  var chart = echarts.init(dom, 'vintage');
-});
+fetch('theme/vintage.json')
+  .then(r => r.json())
+  .then(theme => {
+    echarts.registerTheme('vintage', theme);
+    var chart = echarts.init(dom, 'vintage');
+  })
 ```
 
 如果保存为 UMD 格式的 JS 文件，文件内部已经做了自注册，直接引入 JS 即可：


### PR DESCRIPTION
The existing example set up for an xhr request and then made it with jQuery.  This was a bit confusing: https://lists.apache.org/thread/zm6svhfn26mrk70hnfjyhn4jq1gpoh9q

The change to `fetch` eliminates the need for that global, and jQuery is a bit of a dated approach at this point IMO