### PR TITLE
docs: add horizontal bar chart example

### DIFF
--- a/contents/en/how-to/chart-types/bar/basic-bar.md
+++ b/contents/en/how-to/chart-types/bar/basic-bar.md
@@ -33,8 +33,11 @@ A horizontal bar chart can be created by using a value axis on the X-axis and a 
 
 ```js live
 option = {
-  xAxis: {},
+  xAxis: {
+    type: 'value',
+  },
   yAxis: {
+    type: 'category',
     data:  ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun']
   },
   series: [

--- a/contents/en/how-to/chart-types/bar/basic-bar.md
+++ b/contents/en/how-to/chart-types/bar/basic-bar.md
@@ -33,7 +33,7 @@ A horizontal bar chart can be created by using a value axis on the X-axis and a 
 
 ```js live
 option = {
-  XAxis: {},
+  xAxis: {},
   yAxis: {
     data:  ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun']
   },

--- a/contents/en/how-to/chart-types/bar/basic-bar.md
+++ b/contents/en/how-to/chart-types/bar/basic-bar.md
@@ -27,6 +27,25 @@ option = {
 
 In this case, the x-axis is under the category type. Therefore, you should define some corresponding values for `'xAxis'`. Meanwhile, the data type of the y-axis is numerical. The range of the y-axis will be generated automatically by the `data` in `'series'`.
 
+## Horizontal Bar Chart
+
+A horizontal bar chart can be created by using a value axis on the X-axis and a category axis on the Y-axis.
+
+```js live
+option = {
+  XAxis: {},
+  yAxis: {
+    data:  ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun']
+  },
+  series: [
+    {
+      type: 'bar',
+      data: [23, 24, 18, 25, 27, 28, 25]
+    }
+  ]
+};
+```
+
 ## Multi-series Bar Chart
 
 You may use a series to represent a group of related data. To show multiple series in the same chart, you need to add one more array under the `series`.


### PR DESCRIPTION
## Description

Add a simple horizontal bar chart example to the Basic Bar Chart documentation.

## Changes

- Added a new "Horizontal Bar Chart" section.
- Included a minimal example demonstrating how to swap category and value axes to render horizontal bars.